### PR TITLE
Fix libnetcdf dependency

### DIFF
--- a/pyarts/meta.yaml
+++ b/pyarts/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/pyarts/meta.yaml
+++ b/pyarts/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - matplotlib
     - nomkl  # [linux]
     - netcdf4
+    - libnetcdf=4.9.3
     - openblas=*=*openmp*  # [linux]
     - pip
     - pytest
@@ -57,6 +58,7 @@ requirements:
     - libopenblas=*=*openmp*  # [linux]
     - matplotlib
     - netcdf4
+    - libnetcdf=4.9.3
     - {{ pin_compatible('numpy', lower_bound='1.22', upper_bound='3.0') }}
     - scipy
     - tqdm


### PR DESCRIPTION
libnetcdf changes library name even with minor updates which breaks ARTS linkage. Force same libnetcdf version to be installed that ARTS library was compiled against.